### PR TITLE
Refactor

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,11 +6,13 @@
   "extends": [
     "@tipe/eslint-config-tipe/server",
     "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended",
     "prettier",
     "prettier/@typescript-eslint"
   ],
   "plugins": [
-    "@typescript-eslint"
+    "@typescript-eslint",
+    "prettier"
   ],
   "rules": {
     "indent": "off",

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "singleQuote": true
+}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@tipe/eslint-config-tipe": "^2.1.0",
     "@types/jest": "^24.0.11",
     "@types/lodash": "^4.14.123",
+    "@types/lodash.isarray": "^4.0.6",
     "@types/lodash.isfunction": "^3.0.6",
     "@types/lodash.isobject": "^3.0.6",
     "@types/lodash.isstring": "^4.0.6",
@@ -75,6 +76,7 @@
     "typescript": "^3.4.3"
   },
   "dependencies": {
+    "lodash.isarray": "^4.0.0",
     "lodash.isfunction": "^3.0.9",
     "lodash.isobject": "^3.0.2",
     "lodash.isstring": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -76,11 +76,13 @@
     "typescript": "^3.4.3"
   },
   "dependencies": {
+    "@types/showdown": "^1.9.3",
     "lodash.isarray": "^4.0.0",
     "lodash.isfunction": "^3.0.9",
     "lodash.isobject": "^3.0.2",
     "lodash.isstring": "^4.0.1",
-    "lodash.reduce": "^4.6.0"
+    "lodash.reduce": "^4.6.0",
+    "showdown": "^1.9.0"
   },
   "release": {
     "verifyConditions": [

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/lodash.isfunction": "^3.0.6",
     "@types/lodash.isobject": "^3.0.6",
     "@types/lodash.isstring": "^4.0.6",
+    "@types/lodash.keyby": "^4.6.6",
     "@types/lodash.reduce": "^4.6.6",
     "@typescript-eslint/eslint-plugin": "^1.6.0",
     "@typescript-eslint/parser": "^1.6.0",
@@ -81,6 +82,7 @@
     "lodash.isfunction": "^3.0.9",
     "lodash.isobject": "^3.0.2",
     "lodash.isstring": "^4.0.1",
+    "lodash.keyby": "^4.6.0",
     "lodash.reduce": "^4.6.0",
     "showdown": "^1.9.0"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,8 @@ const whiteList = {
   'lodash.isstring': true,
   'lodash.isfunction': true,
   'lodash.isobject': true,
-  'lodash.isarray': true
+  'lodash.isarray': true,
+  'lodash.keyby': true
 }
 
 const plugins = [
@@ -36,7 +37,8 @@ export default [
         'lodash.isstring': 'isString',
         'lodash.isobject': 'isObject',
         'lodash.isfunction': 'isFunction',
-        'lodash.isarray': 'isArray'
+        'lodash.isarray': 'isArray',
+        'lodash.keyby': 'keyBy'
       }
     }
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,8 @@ import { terser } from 'rollup-plugin-terser'
 const whiteList = {
   'lodash.isstring': true,
   'lodash.isfunction': true,
-  'lodash.isobject': true
+  'lodash.isobject': true,
+  'lodash.isarray': true
 }
 
 const plugins = [
@@ -34,7 +35,8 @@ export default [
       globals: {
         'lodash.isstring': 'isString',
         'lodash.isobject': 'isObject',
-        'lodash.isfunction': 'isFunction'
+        'lodash.isfunction': 'isFunction',
+        'lodash.isarray': 'isArray'
       }
     }
   },

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -1,6 +1,7 @@
 export const TransformerConstants = {
+  blockDataMissing: 'blocks missing',
   missingArguments: 'Transformer needs contain data and a parser',
   somethingWentWrong: 'Something went wrong',
   invalidParser:
-    'invalid parser must be a function or Tipe supported parser (currently: html)'
+    'invalid parser must be a function or Tipe supported parser (currently: html, markdown)'
 }

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -1,5 +1,6 @@
 export const TransformerConstants = {
   missingArguments: 'Transformer needs contain data and a parser',
   somethingWentWrong: 'Something went wrong',
-  invalidParser: 'invalid parser'
+  invalidParser:
+    'invalid parser must be a function or Tipe supported parser (currently: html)'
 }

--- a/src/helpers/mockBlocks.json
+++ b/src/helpers/mockBlocks.json
@@ -1,30 +1,62 @@
 {
-    "apiId": "title",
-    "blocks": [
-        {
-            "id": "asdfasdf",
-            "content": "<p>sdfasdfasdf</p>",
-            "type": "text"
-        },
-        {
-            "id": "asdfasdf",
-            "content": "button cta",
-            "type": "button"
-        },
-        {
-            "id": "asdfasdf",
-            "content": "https://dev.cdn.tipe.io/adfasdfasdf",
-            "type": "image"
-        },
-        {
-            "id": "asdfasdf",
-            "content": "### header 3",
-            "type": "markdown"
-        },
-        {
-            "id": "asdfasdf",
-            "content": "var tipe = clean",
-            "type": "code"
-        }
-    ]
+    "hero": {
+        "apiId": "hero",
+        "blocks": [
+            {
+                "id": "asdfasdf",
+                "content": "<p>sdfasdfasdf</p>",
+                "type": "text"
+            },
+            {
+                "id": "asdfasdf",
+                "content": "button cta",
+                "type": "button"
+            },
+            {
+                "id": "asdfasdf",
+                "content": "https://dev.cdn.tipe.io/adfasdfasdf",
+                "type": "image"
+            },
+            {
+                "id": "asdfasdf",
+                "content": "### header 3",
+                "type": "markdown"
+            },
+            {
+                "id": "asdfasdf",
+                "content": "var tipe = clean",
+                "type": "code"
+            }
+        ]
+    },
+    "body": {
+        "apiId": "body",
+        "blocks": [
+            {
+                "id": "asdfasdf",
+                "content": "<p>sdfasdfasdf</p>",
+                "type": "text"
+            },
+            {
+                "id": "asdfasdf",
+                "content": "button cta",
+                "type": "button"
+            },
+            {
+                "id": "asdfasdf",
+                "content": "https://dev.cdn.tipe.io/adfasdfasdf",
+                "type": "image"
+            },
+            {
+                "id": "asdfasdf",
+                "content": "### header 3",
+                "type": "markdown"
+            },
+            {
+                "id": "asdfasdf",
+                "content": "var tipe = clean",
+                "type": "code"
+            }
+        ]
+    }
 }

--- a/src/helpers/mockBlocks.json
+++ b/src/helpers/mockBlocks.json
@@ -1,113 +1,30 @@
 {
-  "id" : 1555627973807,
-  "sections": {
-    "section name": [
+    "apiId": "title",
+    "blocks": [
         {
-            "type" : "header",
-            "data" : {
-                "text" : "Tipe.io",
-                "level" : 2
-            }
+            "id": "asdfasdf",
+            "content": "<p>sdfasdfasdf</p>",
+            "type": "text"
         },
         {
-            "type" : "paragraph",
-            "data" : {
-                "text" : "Take our new editor for a spin!"
-            }
+            "id": "asdfasdf",
+            "content": "button cta",
+            "type": "button"
         },
         {
-            "type" : "header",
-            "data" : {
-                "text" : "Key features",
-                "level" : 3
-            }
+            "id": "asdfasdf",
+            "content": "https://dev.cdn.tipe.io/adfasdfasdf",
+            "type": "image"
         },
         {
-            "type" : "list",
-            "data" : {
-                "style" : "unordered",
-                "items" : [
-                    "It is a block-styled editor",
-                    "It returns clean data output in JSON",
-                    "Designed to be extendable and pluggable with a simple API"
-                ]
-            }
+            "id": "asdfasdf",
+            "content": "### header 3",
+            "type": "markdown"
         },
         {
-            "type" : "header",
-            "data" : {
-                "text" : "What does it mean «block-styled editor»",
-                "level" : 3
-            }
-        },
-        {
-            "type" : "paragraph",
-            "data" : {
-                "text" : "Workspace in classic editors is made of a single contenteditable element, used to create different HTML markups. Editor.js <mark class=\"cdx-marker\">workspace consists of separate Blocks: paragraphs, headings, images, lists, quotes, etc</mark>. Each of them is an independent contenteditable element (or more complex structure) provided by Plugin and united by Editor's Core."
-            }
-        },
-        {
-            "type" : "paragraph",
-            "data" : {
-                "text" : "There are dozens of <a href=\"https://github.com/editor-js\">ready-to-use Blocks</a> and the <a href=\"https://editorjs.io/creating-a-block-tool\">simple API</a> for creation any Block you need. For example, you can implement Blocks for Tweets, Instagram posts, surveys and polls, CTA-buttons and even games."
-            }
-        },
-        {
-            "type" : "header",
-            "data" : {
-                "text" : "What does it mean clean data output",
-                "level" : 3
-            }
-        },
-        {
-            "type" : "paragraph",
-            "data" : {
-                "text" : "Classic WYSIWYG-editors produce raw HTML-markup with both content data and content appearance. On the contrary, Editor.js outputs JSON object with data of each Block. You can see an example below"
-            }
-        }
-    ],
-    "section name 2": [
-        {
-            "type" : "paragraph",
-            "data" : {
-                "text" : "Given data can be used as you want: render with HTML for <code class=\"inline-code\">Web clients</code>, render natively for <code class=\"inline-code\">mobile apps</code>, create markup for <code class=\"inline-code\">Facebook Instant Articles</code> or <code class=\"inline-code\">Google AMP</code>, generate an <code class=\"inline-code\">audio version</code> and so on."
-            }
-        },
-        {
-            "type" : "paragraph",
-            "data" : {
-                "text" : "Clean data is useful to sanitize, validate and process on the backend."
-            }
-        },
-        {
-            "type" : "delimiter",
-            "data" : {}
-        },
-        {
-            "type" : "paragraph",
-            "data" : {
-                "text" : "We have been working on this project more than three years. Several large media projects help us to test and debug the Editor, to make it's core more stable. At the same time we significantly improved the API. Now, it can be used to create any plugin for any task. Hope you enjoy. 😏"
-            }
-        },
-        {
-            "type" : "image",
-            "data" : {
-                "file" : {
-                    "url" : "https://codex.so/upload/redactor_images/o_e48549d1855c7fc1807308dd14990126.jpg"
-                },
-                "caption" : "",
-                "withBorder" : true,
-                "stretched" : false,
-                "withBackground" : false
-            }
-        },
-        {
-            "type" : "list",
-            "data" : {
-                "style" : "ordered",
-                "items" : ["item1", "item2"]
-            }
+            "id": "asdfasdf",
+            "content": "var tipe = clean",
+            "type": "code"
         }
     ]
-  }
 }

--- a/src/transformer.spec.ts
+++ b/src/transformer.spec.ts
@@ -3,17 +3,17 @@ import { TransformerConstants } from './helpers/constants'
 import * as mockBlocks from './helpers/mockBlocks.json'
 
 describe('transformer', () => {
-  it('should take a tipeParser name as a string and use the corresponding tipeParser', () => {
-    const html = transformer(mockBlocks, 'html')
-    expect(html.length).toBeGreaterThan(1)
+  it('should take a tipeParser name as a string and use the corresponding tipeParser', async () => {
+    const html = await transformer(mockBlocks, 'html')
+    expect(html.result.length).toBeGreaterThan(1)
   })
 
-  it('should throw if the parser argument is a string and does not map to a tipeParser', () => {
-    const htmlCaller = () => {
-      return transformer(mockBlocks, 'foo')
+  it('should throw if the parser argument is a string and does not map to a tipeParser', async () => {
+    const htmlCaller = async () => {
+      await transformer(mockBlocks, 'foo')
     }
 
-    expect(htmlCaller).toThrow(TransformerConstants.invalidParser)
+    await expect(htmlCaller()).rejects.toThrow(new Error(TransformerConstants.invalidParser))
   })
 
   it('should use a parser function if passed in', () => {
@@ -22,11 +22,4 @@ describe('transformer', () => {
     expect(mockFunction).toHaveBeenCalled()
   })
 
-  it('should use a every parser function if array of functions passed in', () => {
-    const mockFunction1 = jest.fn()
-    const mockFunction2 = jest.fn()
-    transformer(mockBlocks, [mockFunction1, mockFunction2])
-    expect(mockFunction2).toHaveBeenCalled()
-    expect(mockFunction1).toHaveBeenCalled()
-  })
 })

--- a/src/transformer.spec.ts
+++ b/src/transformer.spec.ts
@@ -1,6 +1,7 @@
 import { transformer } from './transformer'
 import { TransformerConstants } from './helpers/constants'
 import * as mockBlocks from './helpers/mockBlocks.json'
+import { stringLiteral, identifier } from '@babel/types';
 
 describe('transformer', () => {
   it('should take a tipeParser name as a string and use the corresponding tipeParser', async () => {

--- a/src/transformer.spec.ts
+++ b/src/transformer.spec.ts
@@ -1,12 +1,12 @@
 import { transformer } from './transformer'
 import { TransformerConstants } from './helpers/constants'
 import * as mockBlocks from './helpers/mockBlocks.json'
-import { stringLiteral, identifier } from '@babel/types';
 
 describe('transformer', () => {
   it('should take a tipeParser name as a string and use the corresponding tipeParser', async () => {
-    const html = await transformer(mockBlocks, 'html')
-    expect(html.result.length).toBeGreaterThan(1)
+    const parsedValue = await transformer(mockBlocks, 'html')
+    const apiId = "hero"
+    expect(parsedValue.result.sections[apiId]).toBeTruthy()
   })
 
   it('should throw if the parser argument is a string and does not map to a tipeParser', async () => {

--- a/src/transformer.spec.ts
+++ b/src/transformer.spec.ts
@@ -21,4 +21,12 @@ describe('transformer', () => {
     transformer(mockBlocks, mockFunction)
     expect(mockFunction).toHaveBeenCalled()
   })
+
+  it('should use a every parser function if array of functions passed in', () => {
+    const mockFunction1 = jest.fn()
+    const mockFunction2 = jest.fn()
+    transformer(mockBlocks, [mockFunction1, mockFunction2])
+    expect(mockFunction2).toHaveBeenCalled()
+    expect(mockFunction1).toHaveBeenCalled()
+  })
 })

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,12 +1,10 @@
 import isString from 'lodash.isstring'
 import isObject from 'lodash.isobject'
 import isFunction from 'lodash.isfunction'
-import isArray from 'lodash.isarray'
 
 import { ISectionData, ITipeTransformers } from './types'
 import { TransformerConstants } from './helpers/constants'
 import { transformHTML } from './transformers/html'
-import { resolve } from 'dns'
 
 export const tipeParsers: ITipeTransformers = {
   html: transformHTML
@@ -31,10 +29,13 @@ export const validBlockData = (data: ISectionData): ISectionData => {
 export const validParser = (
   parser: string | (() => string) | (() => string | string)[]
 ): ((data: ISectionData) => string) => {
-  if (isString(parser) && tipeParsers.hasOwnProperty(parser))
+  if (isString(parser) && tipeParsers.hasOwnProperty(parser)) {
     return tipeParsers[parser]
+  }
 
-  if (isFunction(parser)) return parser
+  if (isFunction(parser)) {
+    return parser
+  }
 
   throw new Error(TransformerConstants.invalidParser)
 }
@@ -42,7 +43,7 @@ export const validParser = (
 export const transformer = (
   data: ISectionData,
   parser: string | (() => string) | (() => string | string)[]
-): Promise<object> => {
+): Promise<{ result: string; blocks: object }> => {
   return new Promise(
     (resolve, reject): void => {
       if (!data || !parser) {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -47,40 +47,40 @@ export const validParser = (
 }
 
 export const handleParserArray = (
-  parserArr: string[] | (string | ((blocks: IBlock) => string))[],
+  parserArr: string[] | (string | ((block: IBlock) => string))[],
   blockData: ISectionData
-): { result: string; blocks: ISectionData } => {
+): { result: string[]; blocks: ISectionData } => {
   const { blocks } = blockData
   const result = reduce(
     blocks,
-    (htmlResult: string, block: IBlock): string => {
+    (parsedResult: string[], block: IBlock): string[] => {
       parserArr.forEach(
         (parser): void => {
           const validParseMethod = validParser(parser)
-          htmlResult += validParseMethod(block)
+          parsedResult.push(validParseMethod(block))
         }
       )
-      return htmlResult
+      return parsedResult.filter(Boolean)
     },
-    ''
+    []
   )
 
   return { result, blocks: blockData }
 }
 
 export const handleSingleParser = (
-  parser: (() => string) | string | any,
+  parser: string | (() => string),
   blockData: ISectionData
-): { result: string; blocks: object } => {
+): { result: string[]; blocks: object } => {
   const validParseMethod = validParser(parser)
   const { blocks } = blockData
   const result = reduce(
     blocks,
-    (htmlResult: string, block: IBlock): string => {
-      htmlResult += validParseMethod(block)
-      return htmlResult
+    (parsedResult: string[], block: IBlock): string[] => {
+      parsedResult.push(validParseMethod(block))
+      return parsedResult.filter(Boolean)
     },
-    ''
+    []
   )
   return {
     result,
@@ -90,8 +90,8 @@ export const handleSingleParser = (
 
 export const transformer = (
   data: ISectionData,
-  parser: string | (() => string) | (() => string | string)[]
-): Promise<{ result: string; blocks: object }> => {
+  parser: string | (() => string) | any
+): Promise<{ result: string[]; blocks: object }> => {
   return new Promise(
     (resolve, reject): void => {
       if (!data || !parser) {

--- a/src/transformers/html/transformHTML.spec.ts
+++ b/src/transformers/html/transformHTML.spec.ts
@@ -12,7 +12,7 @@ describe('transformerHTML', () => {
         type: `text`
       }]
     }
-    const html = transformHTML(sectionData)
+    const html = transformHTML('', sectionData)
     expect(html).toBe(`<p>sdfasdfasdf</p>`)
   })
 
@@ -26,7 +26,7 @@ describe('transformerHTML', () => {
         type: `button`
       }]
     }
-    const html = transformHTML(sectionData)
+    const html = transformHTML('', sectionData)
     expect(html).toBe(`<button>button cta</button>`)
   })
 
@@ -40,7 +40,7 @@ describe('transformerHTML', () => {
         type: `image`
       }]
     }
-    const html = transformHTML(sectionData)
+    const html = transformHTML('', sectionData)
     expect(html).toBe(`<img src="https://dev.cdn.tipe.io/adfasdfasdf" />`)
   })
 
@@ -56,7 +56,7 @@ describe('transformerHTML', () => {
         type: `code`
       }]
     }
-    const html = transformHTML(sectionData)
+    const html = transformHTML('', sectionData)
     expect(html).toBe(`<pre><code>var tipe = clean</code></pre>`)
   })
 })

--- a/src/transformers/html/transformHTML.spec.ts
+++ b/src/transformers/html/transformHTML.spec.ts
@@ -56,11 +56,14 @@ describe('transformerHTML', () => {
       blocks: [{
         apiId: 'asdfasdf',
         content: `var tipe = clean`,
-        type: `code`
+        type: `code`,
+        data: {
+          lang: 'javascript'
+        }
       }]
     }
     const block = sectionData.blocks[0]
     const html = transformHTML(block)
-    expect(html).toBe(`<pre><code>var tipe = clean</code></pre>`)
+    expect(html).toBe(`<pre><code class="javascript javascript-css">var tipe = clean</code></pre>`)
   })
 })

--- a/src/transformers/html/transformHTML.spec.ts
+++ b/src/transformers/html/transformHTML.spec.ts
@@ -2,115 +2,61 @@ import { transformHTML } from './transformHTML'
 import { TransformerConstants } from '../../helpers/constants'
 
 describe('transformerHTML', () => {
-  it('should correctly transform a header block', () => {
-    const collectionData = {
-      id: 1234,
-      sections: {
-        'section 1': [
-          {
-            type: 'header',
-            data: {
-              text: 'tipe.io',
-              level: 2
-            }
-          }
-        ]
-      }
+  // Text block
+  it('should correctly transform a text block', () => {
+    const sectionData = {
+      apiId: 'asdfasdf',
+      blocks: [{
+        id: 'asdfasdf',
+        content: `<p>sdfasdfasdf</p>`,
+        type: `text`
+      }]
     }
-    const html = transformHTML(collectionData)
-    expect(html).toBe(`<h2>tipe.io</h2>`)
+    const html = transformHTML(sectionData)
+    expect(html).toBe(`<p>sdfasdfasdf</p>`)
   })
 
-  it('should correctly transform a paragraph block', () => {
-    const collectionData = {
-      id: 1234,
-      sections: {
-        'section 1': [
-          {
-            type: 'paragraph',
-            data: {
-              text: 'tipe.io'
-            }
-          }
-        ]
-      }
+  // Button block
+  it('should correctly transform a button block', () => {
+    const sectionData = {
+      apiId: 'asdfasdf',
+      blocks: [{
+        id: 'asdfasdf',
+        content: `button cta`,
+        type: `button`
+      }]
     }
-    const html = transformHTML(collectionData)
-    expect(html).toBe(`<p>tipe.io</p>`)
+    const html = transformHTML(sectionData)
+    expect(html).toBe(`<button>button cta</button>`)
   })
 
-  it('should correctly transform an unordered list block', () => {
-    const collectionData = {
-      id: 1234,
-      sections: {
-        'section 1': [
-          {
-            type: 'list',
-            data: {
-              style: 'unordered',
-              items: ['tipe has improved our companies culture', 'tipe.io is my friend']
-            }
-          }
-        ]
-      }
-    }
-    const html = transformHTML(collectionData)
-    expect(html).toBe(`<ul><li>tipe has improved our companies culture</li><li>tipe.io is my friend</li></ul>`)
-  })
-
-  it('should correctly transform an ordered list block', () => {
-    const collectionData = {
-      id: 1234,
-      sections: {
-        'section 1': [
-          {
-            type: 'list',
-            data: {
-              style: 'ordered',
-              items: ['tipe has improved our companies culture', 'tipe.io is my friend']
-            }
-          }
-        ]
-      }
-    }
-    const html = transformHTML(collectionData)
-    expect(html).toBe(`<ol><li>tipe has improved our companies culture</li><li>tipe.io is my friend</li></ol>`)
-  })
-
-  it('should correctly transform a delimiter block', () => {
-    const collectionData = {
-      id: 1234,
-      sections: {
-        'section 1': [
-          {
-            type: 'delimiter',
-            data: {}
-          }
-        ]
-      }
-    }
-    const html = transformHTML(collectionData)
-    expect(html).toBe(`<hr>`)
-  })
-
+  // Image block
   it('should correctly transform an image block', () => {
-    const collectionData = {
-      id: 1234,
-      sections: {
-        'section 1': [
-          {
-            type: 'image',
-            data: {
-              file: {
-                url: 'someurl'
-              },
-              caption: 'somecaption'
-            }
-          }
-        ]
-      }
+    const sectionData = {
+      apiId: 'asdfasdf',
+      blocks: [{
+        id: 'asdfasdf',
+        content: `https://dev.cdn.tipe.io/adfasdfasdf`,
+        type: `image`
+      }]
     }
-    const html = transformHTML(collectionData)
-    expect(html).toBe(`<img src="someurl" alt="somecaption" />`)
+    const html = transformHTML(sectionData)
+    expect(html).toBe(`<img src="https://dev.cdn.tipe.io/adfasdfasdf" />`)
+  })
+
+  // Markdown block to be handled by user
+
+  // Code block
+  it('should correctly transform an code block', () => {
+    const sectionData = {
+      apiId: 'asdfasdf',
+      blocks: [{
+        id: 'asdfasdf',
+        content: `var tipe = clean`,
+        type: `code`
+      }]
+    }
+    const html = transformHTML(sectionData)
+    expect(html).toBe(`<pre><code>var tipe = clean</code></pre>`)
   })
 })

--- a/src/transformers/html/transformHTML.spec.ts
+++ b/src/transformers/html/transformHTML.spec.ts
@@ -7,12 +7,13 @@ describe('transformerHTML', () => {
     const sectionData = {
       apiId: 'asdfasdf',
       blocks: [{
-        id: 'asdfasdf',
+        apiId: 'asdfasdf',
         content: `<p>sdfasdfasdf</p>`,
         type: `text`
       }]
     }
-    const html = transformHTML('', sectionData)
+    const block = sectionData.blocks[0]
+    const html = transformHTML(block)
     expect(html).toBe(`<p>sdfasdfasdf</p>`)
   })
 
@@ -21,12 +22,13 @@ describe('transformerHTML', () => {
     const sectionData = {
       apiId: 'asdfasdf',
       blocks: [{
-        id: 'asdfasdf',
+        apiId: 'asdfasdf',
         content: `button cta`,
         type: `button`
       }]
     }
-    const html = transformHTML('', sectionData)
+    const block = sectionData.blocks[0]
+    const html = transformHTML(block)
     expect(html).toBe(`<button>button cta</button>`)
   })
 
@@ -35,12 +37,13 @@ describe('transformerHTML', () => {
     const sectionData = {
       apiId: 'asdfasdf',
       blocks: [{
-        id: 'asdfasdf',
+        apiId: 'asdfasdf',
         content: `https://dev.cdn.tipe.io/adfasdfasdf`,
         type: `image`
       }]
     }
-    const html = transformHTML('', sectionData)
+    const block = sectionData.blocks[0]
+    const html = transformHTML(block)
     expect(html).toBe(`<img src="https://dev.cdn.tipe.io/adfasdfasdf" />`)
   })
 
@@ -51,12 +54,13 @@ describe('transformerHTML', () => {
     const sectionData = {
       apiId: 'asdfasdf',
       blocks: [{
-        id: 'asdfasdf',
+        apiId: 'asdfasdf',
         content: `var tipe = clean`,
         type: `code`
       }]
     }
-    const html = transformHTML('', sectionData)
+    const block = sectionData.blocks[0]
+    const html = transformHTML(block)
     expect(html).toBe(`<pre><code>var tipe = clean</code></pre>`)
   })
 })

--- a/src/transformers/html/transformHTML.ts
+++ b/src/transformers/html/transformHTML.ts
@@ -1,29 +1,29 @@
 import reduce from 'lodash.reduce'
-import { ISectionData, IBlock } from '../../types'
+import { IBlock } from '../../types'
 
-export const transformHTML = (html: string, data: ISectionData): string => {
+export const transformHTML = (block: IBlock): string => {
   const result = reduce(
-    data.blocks,
-    (htmlResult: string, blockVal: IBlock): string => {
-      switch (blockVal.type) {
+    block,
+    (htmlResult: string, blockVal: any): string => {
+      switch (blockVal) {
         case 'text':
-          htmlResult += blockVal.content
+          htmlResult += block.content
           break
         case 'button':
-          htmlResult += `<button>${blockVal.content}</button>`
+          htmlResult += `<button>${block.content}</button>`
           break
         case 'image':
-          htmlResult += `<img src="${blockVal.content}" />`.replace(/\\"/g, '"')
+          htmlResult += `<img src="${block.content}" />`.replace(/\\"/g, '"')
           break
         case 'code':
-          htmlResult += `<pre><code>${blockVal.content}</code></pre>`
+          htmlResult += `<pre><code>${block.content}</code></pre>`
           break
         default:
           break
       }
       return htmlResult
     },
-    html
+    ''
   )
   return result
 }

--- a/src/transformers/html/transformHTML.ts
+++ b/src/transformers/html/transformHTML.ts
@@ -1,67 +1,29 @@
 import reduce from 'lodash.reduce'
-import {
-  ICollectionData,
-  ISection,
-  IListTypes,
-  IBlockFields
-} from '../../types'
+import { ISectionData, IBlock } from '../../types'
 
-export const transformHTML = (data: ICollectionData): string => {
+export const transformHTML = (data: ISectionData): string => {
   return reduce(
-    data.sections,
-    (html: string, sectionVal: ISection[]): string => {
+    data.blocks,
+    (html: string, blockVal: IBlock): string => {
       let element: string
-
-      const listTypes: IListTypes = {
-        ordered: 'ol',
-        unordered: 'ul'
+      switch (blockVal.type) {
+        case 'text':
+          element = blockVal.content
+          break
+        case 'button':
+          element = `<button>${blockVal.content}</button>`
+          break
+        case 'image':
+          element = `<img src="${blockVal.content}" />`.replace(/\\"/g, '"')
+          break
+        case 'code':
+          element = `<pre><code>${blockVal.content}</code></pre>`
+          break
+        default:
+          element = ''
+          break
       }
-
-      sectionVal.forEach(
-        (block: IBlockFields): void => {
-          switch (block.type) {
-            case 'header':
-              const { level, text } = block.data
-              element = `<h${level}>${text}</h${level}>`
-              break
-
-            case 'paragraph':
-              element = `<p>${block.data.text}</p>`
-              break
-
-            case 'list':
-              const { items, style } = block.data
-
-              if (!items) throw new Error('items not defined!')
-              if (!style) throw new Error('style not defined!')
-
-              const type: string = listTypes[style]
-              const li: string = items
-                .map((i: string): string => `<li>${i}</li>`)
-                .join('')
-
-              element = `<${type}>${li}</${type}>`
-              break
-            case 'delimiter':
-              element = '<hr>'
-              break
-            case 'image':
-              const { file, caption } = block.data
-              if (!file) throw new Error('file not defined!')
-              element = `<img src="${file.url}" alt="${caption}" />`.replace(
-                /\\"/g,
-                '"'
-              )
-              break
-            default:
-              element = ''
-              break
-          }
-
-          html += element
-        }
-      )
-
+      html += element
       return html
     },
     ''

--- a/src/transformers/html/transformHTML.ts
+++ b/src/transformers/html/transformHTML.ts
@@ -1,31 +1,29 @@
 import reduce from 'lodash.reduce'
 import { ISectionData, IBlock } from '../../types'
 
-export const transformHTML = (data: ISectionData): string => {
-  return reduce(
+export const transformHTML = (html: string, data: ISectionData): string => {
+  const result = reduce(
     data.blocks,
-    (html: string, blockVal: IBlock): string => {
-      let element: string
+    (htmlResult: string, blockVal: IBlock): string => {
       switch (blockVal.type) {
         case 'text':
-          element = blockVal.content
+          htmlResult += blockVal.content
           break
         case 'button':
-          element = `<button>${blockVal.content}</button>`
+          htmlResult += `<button>${blockVal.content}</button>`
           break
         case 'image':
-          element = `<img src="${blockVal.content}" />`.replace(/\\"/g, '"')
+          htmlResult += `<img src="${blockVal.content}" />`.replace(/\\"/g, '"')
           break
         case 'code':
-          element = `<pre><code>${blockVal.content}</code></pre>`
+          htmlResult += `<pre><code>${blockVal.content}</code></pre>`
           break
         default:
-          element = ''
           break
       }
-      html += element
-      return html
+      return htmlResult
     },
-    ''
+    html
   )
+  return result
 }

--- a/src/transformers/html/transformHTML.ts
+++ b/src/transformers/html/transformHTML.ts
@@ -4,24 +4,28 @@ import { IBlock } from '../../types'
 export const transformHTML = (block: IBlock): string => {
   const result = reduce(
     block,
-    (htmlResult: string, blockVal: any): string => {
-      switch (blockVal) {
+    (parsedBlock: string, blockType: any): string => {
+      switch (blockType) {
         case 'text':
-          htmlResult += block.content
+          parsedBlock = block.content
           break
         case 'button':
-          htmlResult += `<button>${block.content}</button>`
+          parsedBlock = `<button>${block.content}</button>`
           break
         case 'image':
-          htmlResult += `<img src="${block.content}" />`.replace(/\\"/g, '"')
+          parsedBlock = `<img src="${block.content}" />`.replace(/\\"/g, '"')
           break
         case 'code':
-          htmlResult += `<pre><code>${block.content}</code></pre>`
+          if (block.data) {
+            parsedBlock = `<pre><code class="${block.data.lang} ${
+              block.data.lang
+            }-css">${block.content}</code></pre>`
+          }
           break
         default:
           break
       }
-      return htmlResult
+      return parsedBlock
     },
     ''
   )

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -1,3 +1,4 @@
 import { transformHTML } from './html'
+import { transformMarkdown } from './markdown'
 
-export { transformHTML }
+export { transformHTML, transformMarkdown }

--- a/src/transformers/markdown/index.ts
+++ b/src/transformers/markdown/index.ts
@@ -1,0 +1,3 @@
+import { transformMarkdown } from './transformMarkdown'
+
+export { transformMarkdown }

--- a/src/transformers/markdown/transformMarkdown.spec.ts
+++ b/src/transformers/markdown/transformMarkdown.spec.ts
@@ -5,12 +5,13 @@ describe('transformMarkdown', () => {
     const sectionData = {
       apiId: 'asdfasdf',
       blocks: [{
-        id: 'asdfasdf',
+        apiId: 'asdfasdf',
         content: `### header 3`,
         type: `markdown`
       }]
     }
-    const html = transformMarkdown('', sectionData)
+    const block = sectionData.blocks[0]
+    const html = transformMarkdown(block)
     expect(html).toBe(`<h3 id="header3">header 3</h3>`)
   })
 })

--- a/src/transformers/markdown/transformMarkdown.spec.ts
+++ b/src/transformers/markdown/transformMarkdown.spec.ts
@@ -1,0 +1,16 @@
+import { transformMarkdown } from './transformMarkdown'
+
+describe('transformMarkdown', () => {
+  it('should correctly transform a markdown block', () => {
+    const sectionData = {
+      apiId: 'asdfasdf',
+      blocks: [{
+        id: 'asdfasdf',
+        content: `### header 3`,
+        type: `markdown`
+      }]
+    }
+    const html = transformMarkdown('', sectionData)
+    expect(html).toBe(`<h3 id="header3">header 3</h3>`)
+  })
+})

--- a/src/transformers/markdown/transformMarkdown.ts
+++ b/src/transformers/markdown/transformMarkdown.ts
@@ -5,16 +5,15 @@ import { IBlock } from '../../types'
 const markdownConverter = new showdown.Converter()
 
 export const transformMarkdown = (block: IBlock): string => {
-  let htmlResult = reduce(
+  let parsedBlock = reduce(
     block,
-    (htmlResult: string, blockVal: any): string => {
-      if (blockVal === 'markdown') {
-        htmlResult = markdownConverter.makeHtml(block.content)
-        return htmlResult
+    (parsedBlock: string, blockType: any): string => {
+      if (blockType === 'markdown') {
+        parsedBlock = markdownConverter.makeHtml(block.content)
       }
-      return htmlResult
+      return parsedBlock
     },
     ''
   )
-  return htmlResult
+  return parsedBlock
 }

--- a/src/transformers/markdown/transformMarkdown.ts
+++ b/src/transformers/markdown/transformMarkdown.ts
@@ -1,0 +1,19 @@
+import reduce from 'lodash.reduce'
+import showdown from 'showdown'
+import { ISectionData, IBlock } from '../../types'
+
+const markdownConverter = new showdown.Converter()
+
+export const transformMarkdown = (html: string, data: ISectionData): string => {
+  return reduce(
+    data.blocks,
+    (htmlResult: string, blockVal: IBlock): string => {
+      if (blockVal.type === 'markdown') {
+        htmlResult += markdownConverter.makeHtml(blockVal.content)
+        return htmlResult
+      }
+      return htmlResult
+    },
+    html
+  )
+}

--- a/src/transformers/markdown/transformMarkdown.ts
+++ b/src/transformers/markdown/transformMarkdown.ts
@@ -1,19 +1,20 @@
 import reduce from 'lodash.reduce'
 import showdown from 'showdown'
-import { ISectionData, IBlock } from '../../types'
+import { IBlock } from '../../types'
 
 const markdownConverter = new showdown.Converter()
 
-export const transformMarkdown = (html: string, data: ISectionData): string => {
-  return reduce(
-    data.blocks,
-    (htmlResult: string, blockVal: IBlock): string => {
-      if (blockVal.type === 'markdown') {
-        htmlResult += markdownConverter.makeHtml(blockVal.content)
+export const transformMarkdown = (block: IBlock): string => {
+  let htmlResult = reduce(
+    block,
+    (htmlResult: string, blockVal: any): string => {
+      if (blockVal === 'markdown') {
+        htmlResult = markdownConverter.makeHtml(block.content)
         return htmlResult
       }
       return htmlResult
     },
-    html
+    ''
   )
+  return htmlResult
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,8 @@
 export interface ISectionData {
-  apiId: string
-  blocks: object
-}
-
-export interface ISection {
-  [type: string]: IBlock[]
+  [type: string]: {
+    apiId: string
+    blocks: IBlock[]
+  }
 }
 
 export interface IBlockData {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,10 +7,14 @@ export interface ISection {
   [type: string]: IBlock[]
 }
 
+export interface IBlockData {
+  lang?: string
+}
 export interface IBlock {
-  type: string
+  [type: string]: string | any
   apiId: string
   content: string
+  data?: IBlockData
 }
 
 export interface ITipeTransformers {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ export interface IBlock {
 }
 
 export interface ITipeTransformers {
-  [type: string]: (html: string, data: ISectionData) => string
-  html: (html: string, data: ISectionData) => string
-  markdown: (html: string, data: ISectionData) => string
+  [type: string]: (block: IBlock) => string
+  html: (block: IBlock) => string
+  markdown: (block: IBlock) => string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
-export interface ICollectionData {
-  id: number
-  sections: object
+export interface ISectionData {
+  apiId: string
+  blocks: object
 }
 
 export interface ISection {
@@ -9,31 +9,11 @@ export interface ISection {
 
 export interface IBlock {
   type: string
-  data: IBlockFields[]
-}
-
-export interface IBlockFields {
-  text?: string
-  level?: number
-  style?: string
-  items?: string[]
-  file?: {
-    url: string
-  }
-  caption?: string
-  withBorder?: boolean
-  withBackground?: boolean
-  stretched?: boolean
-  [type: string]: boolean | string | object | number | string[] | any
+  apiId: string
+  content: string
 }
 
 export interface ITipeTransformers {
-  [type: string]: Function
-  html: Function
-}
-
-export interface IListTypes {
-  ordered: string
-  unordered: string
-  [key: string]: string
+  [type: string]: (data: ISectionData) => string
+  html: (data: ISectionData) => string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface IBlock {
 }
 
 export interface ITipeTransformers {
-  [type: string]: (data: ISectionData) => string
-  html: (data: ISectionData) => string
+  [type: string]: (html: string, data: ISectionData) => string
+  html: (html: string, data: ISectionData) => string
+  markdown: (html: string, data: ISectionData) => string
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,6 @@
     "node_modules",
     "coverage",
     ".rpt2_cache",
-    "**/*.spec.ts"
+    "src/**/*.spec.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "noImplicitAny": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "typeRoots": [
       "node_modules/@types"
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1027,6 +1027,13 @@
   dependencies:
     "@types/jest-diff" "*"
 
+"@types/lodash.isarray@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.isarray/-/lodash.isarray-4.0.6.tgz#5979c4301508d9571dfb740b81a2f172b7382ade"
+  integrity sha512-lXLDKJ4jWhtAd6EVQOGHwX8iKJlITY5J+HAgim6oglepJrPXAv7hdoN7hrJSwpOYZ7oEpMng+bPasl4LZWp4GQ==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash.isfunction@^3.0.6":
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/@types/lodash.isfunction/-/lodash.isfunction-3.0.6.tgz#4b040bf914089ec34f0aacfef81a37237a0a8b8f"
@@ -5433,6 +5440,11 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.isarray@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-4.0.0.tgz#2aca496b28c4ca6d726715313590c02e6ea34403"
+  integrity sha1-KspJayjEym1yZxUxNZDALm6jRAM=
 
 lodash.isfunction@^3.0.9:
   version "3.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1089,6 +1089,11 @@
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
+"@types/showdown@^1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@types/showdown/-/showdown-1.9.3.tgz#eaa881b03a32d3720184731754d3025fc450b970"
+  integrity sha512-akvzSmrvY4J5d3tHzUUiQr0xpjd4Nb3uzWW6dtwzYJ+qW/KdWw5F8NLatnor5q/1LURHnzDA1ReEwCVqcatRnw==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -7894,6 +7899,13 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+showdown@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/showdown/-/showdown-1.9.0.tgz#d49d2a0b6db21b7c2e96ef855f7b3b2a28ef46f4"
+  integrity sha512-x7xDCRIaOlicbC57nMhGfKamu+ghwsdVkHMttyn+DelwzuHOx4OHCVL/UW/2QOLH7BxfCcCCVVUix3boKXJKXQ==
+  dependencies:
+    yargs "^10.0.3"
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -9053,12 +9065,37 @@ yargs-parser@^11.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
+  integrity sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs-parser@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
   integrity sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=
   dependencies:
     camelcase "^4.1.0"
+
+yargs@^10.0.3:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.2.tgz#454d074c2b16a51a43e2fb7807e4f9de69ccb5c5"
+  integrity sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^8.1.0"
 
 yargs@^11.0.0:
   version "11.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1055,6 +1055,13 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.keyby@^4.6.6":
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.keyby/-/lodash.keyby-4.6.6.tgz#49fcbd6a42dae30f8b271bca4ecb076f310c129d"
+  integrity sha512-4Y6+lMFnMfB6FZoZbX4VB2puzIMDe0wDxMoxlOx4bNASAAgx3PtINs6+mcOUQzvljgFjy3GylRyZeCW6C2DwOQ==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash.reduce@^4.6.6":
   version "4.6.6"
   resolved "https://registry.yarnpkg.com/@types/lodash.reduce/-/lodash.reduce-4.6.6.tgz#064fe105f1717d0af8d3d9894aedc57f51df3f11"
@@ -5470,6 +5477,11 @@ lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
+lodash.keyby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.keyby/-/lodash.keyby-4.6.0.tgz#7f6a1abda93fd24e22728a4d361ed8bcba5a4354"
+  integrity sha1-f2oavak/0k4icopNNh7YvLpaQ1Q=
 
 lodash.reduce@^4.6.0:
   version "4.6.0"


### PR DESCRIPTION
Updated PR:

- Can now accept a function, the name of a supported function, an array of custom functions, or mixed with a string name of a supported function and/or custom functions
- Code cleanup

- Known issues, ~~when using the lib, order matters. ex: If you parse markdown first, it will render first~~ this issue has been addressed in the latest PR